### PR TITLE
Integrate MCP protocol with existing JSON-RPC 2.0 implementation

### DIFF
--- a/src/commands/tools/createComand.ts
+++ b/src/commands/tools/createComand.ts
@@ -5,12 +5,12 @@
  * @param params - The parameters of the method.
  * @returns The JSON-RPC request object as a string.
  */
+import { createMCPRequest, createMCPResponse } from '../../types/specs/mcp-bridge/factories';
+import { MCPRequest, MCPResponse } from '../../types/specs/mcp-bridge/index';
+
 export function createRPCRequest<T>(method: string, params: T): string {
-  return JSON.stringify({
-    jsonrpc: '2.0',
-    method,
-    params,
-  });
+  const request: MCPRequest<T> = createMCPRequest(method, params, Date.now());
+  return JSON.stringify(request);
 }
 
 /**
@@ -20,11 +20,11 @@ export function createRPCRequest<T>(method: string, params: T): string {
  * @returns The JSON-RPC response object as a string.
  */
 export function createRPCResponse<T>(result: Error | T): string {
-  const rpcResponse =
+  const response: MCPResponse<T> =
     result instanceof Error
-      ? { jsonrpc: '2.0', error: result.message }
-      : { jsonrpc: '2.0', result };
-  return JSON.stringify(rpcResponse);
+      ? createMCPResponse(Date.now(), { code: -1, message: result.message })
+      : createMCPResponse(Date.now(), result);
+  return JSON.stringify(response);
 }
 
 /**

--- a/src/core/RpcWorkerPool-slim.ts
+++ b/src/core/RpcWorkerPool-slim.ts
@@ -1,4 +1,3 @@
-// src/core/RpcWorkerPool-slim.ts
 import { cpus } from 'node:os';
 import { Worker } from 'node:worker_threads';
 import { baseRpcResponseRight } from '../server/API/RPC-serialise';
@@ -15,6 +14,7 @@ import type {
   WorkerPoolRpc,
 } from '../types';
 import { tsnodeWorkerGenerator } from './workerGenerator';
+import { MCPRequest, MCPResponse } from '../types/specs/mcp-bridge';
 
 abstract class Rpc {
   private _size: number;
@@ -116,7 +116,7 @@ interface WorkerManagement {
 
 interface RpcExecution {
   execRpc<ResultsType = unknown>(
-    rpcRequest: RpcRequest<string[]>
+    rpcRequest: RpcRequest<string[]> | MCPRequest<string[]>
   ): Promise<ResultsType>;
   exec<O = unknown>(
     command_name: string,
@@ -164,7 +164,7 @@ export class RpcWorkerPool
         __dirname,
         employee_number,
         Worker
-      ).on('message', (msg: RpcResponse<unknown, unknown>) => {
+      ).on('message', (msg: RpcResponse<unknown, unknown> | MCPResponse<unknown>) => {
         this.onMessageHandler(msg, employee_number);
       });
       const employee = {
@@ -192,7 +192,7 @@ export class RpcWorkerPool
     this.employeesSortedByLoad.splice(index, 0, employee);
   }
   public async execRpc<ResultsType = unknown>(
-    rpcRequest: RpcRequest<string[]>
+    rpcRequest: RpcRequest<string[]> | MCPRequest<string[]>
   ): Promise<ResultsType> {
     return this.exec<ResultsType>(
       rpcRequest.method,
@@ -212,7 +212,7 @@ export class RpcWorkerPool
       internal_job_ref,
       external_message_identifier
     );
-    const rpcRequest: RpcRequest<{}> = {
+    const rpcRequest: RpcRequest<{}> | MCPRequest<{}> = {
       jsonrpc: '2.0',
       id: Number(internal_job_ref),
       method: command_name,
@@ -235,7 +235,7 @@ export class RpcWorkerPool
       in_flight_commands: Map<number, any>;
       employee_number: number;
     },
-    rpcRequest: RpcRequest<{}>
+    rpcRequest: RpcRequest<{}> | MCPRequest<{}>
   ): Promise<void> {
     let retries = this.maxRetries;
     while (retries > 0) {
@@ -273,7 +273,7 @@ export class RpcWorkerPool
   }
 
   private onMessageHandler(
-    msg: RpcResponse<any>,
+    msg: RpcResponse<any> | MCPResponse<any>,
     employee_number: number
   ): void {
     const worker = this.employees[employee_number];

--- a/src/core/RpcWorkerPool.ts
+++ b/src/core/RpcWorkerPool.ts
@@ -1,5 +1,3 @@
-// src/core/RpcWorkerPool.ts
-
 import { cpus } from 'node:os';
 import { Worker } from 'node:worker_threads';
 import { baseRpcResponseRight } from '../server/API/RPC-serialise';
@@ -16,6 +14,7 @@ import type {
   WorkerPoolRpc,
 } from '../types';
 import { tsnodeWorkerGenerator } from './workerGenerator';
+import { MCPRequest, MCPResponse } from '../types/specs/mcp-bridge';
 
 // RpcWorkerPool class implements WorkerPool and WorkerPoolRpc
 export class RpcWorkerPool implements WorkerPool, WorkerPoolRpc {
@@ -95,7 +94,7 @@ export class RpcWorkerPool implements WorkerPool, WorkerPoolRpc {
         __dirname,
         employee_number,
         Worker
-      ).on('message', (msg: RpcResponse<unknown, unknown>) => {
+      ).on('message', (msg: RpcResponse<unknown, unknown> | MCPResponse<unknown>) => {
         // Attach message listener for each worker to handle responses
         this.onMessageHandler(msg, employee_number);
       });
@@ -135,7 +134,7 @@ export class RpcWorkerPool implements WorkerPool, WorkerPoolRpc {
 
   // Method to execute an RPC request, delegating to `exec` method
   async execRpc<ResultsType = unknown>(
-    rpcRequest: RpcRequest<string[]>
+    rpcRequest: RpcRequest<string[]> | MCPRequest<string[]>
   ): Promise<ResultsType> {
     // Call the general exec method with the parameters from rpcRequest
     return this.exec<ResultsType>(
@@ -165,7 +164,7 @@ export class RpcWorkerPool implements WorkerPool, WorkerPoolRpc {
     );
 
     // Construct the RPC request with details including job references and arguments
-    const rpcRequest: RpcRequest<{}> = {
+    const rpcRequest: RpcRequest<{}> | MCPRequest<{}> = {
       jsonrpc: '2.0',
       id: Number(internal_job_ref),
       method: command_name,
@@ -254,7 +253,7 @@ export class RpcWorkerPool implements WorkerPool, WorkerPoolRpc {
 
   // Private handler to process messages from workers
   private onMessageHandler(
-    msg: RpcResponse<any>,
+    msg: RpcResponse<any> | MCPResponse<any>,
     employee_number: number
   ): void {
     // Get the worker object and retrieve the command from in-flight commands

--- a/src/server/API/RPC-serialise.ts
+++ b/src/server/API/RPC-serialise.ts
@@ -9,8 +9,10 @@ import type {
   RpcRight,
 } from '../../types/specs';
 
+import type { MCPResponse } from '../../types/specs/mcp-bridge';
+
 export function baseRpcResponseRight<R>(result: R) {
-  return (responseId: number | string): RpcRight<R> => ({
+  return (responseId: number | string): RpcRight<R> | MCPResponse<R> => ({
     jsonrpc: '2.0' as const,
     id: responseId,
     result,

--- a/src/server/API/baseRpcRequest.ts
+++ b/src/server/API/baseRpcRequest.ts
@@ -6,6 +6,7 @@
  * @packageDocumentation
  */
 import type { RpcRequest } from '../../types/specs';
+import type { MCPRequest } from '../../types/specs/mcp-bridge';
 
 export type RpcArgs = Record<string, unknown> | [unknown, ...unknown[]];
 /**
@@ -43,7 +44,7 @@ export function rpcRequestMethodHandler<Q extends RpcArgs>(methodName: string) {
      */
     return function rpcRequestIdHandler(
       requestId: number | `${number}`
-    ): RpcRequest<P> {
+    ): RpcRequest<P> | MCPRequest<P> {
       return {
         jsonrpc: '2.0' as const,
         method: methodName,
@@ -56,7 +57,7 @@ export function rpcRequestMethodHandler<Q extends RpcArgs>(methodName: string) {
 
 export const createRpcRequest =
   <Q extends RpcArgs>(methodName: string) =>
-  <P extends RpcArgs = Q>(args: P, Id: numberStr): RpcRequest<P> =>
+  <P extends RpcArgs = Q>(args: P, Id: numberStr): RpcRequest<P> | MCPRequest<P> =>
     rpcRequestMethodHandler<Q>(methodName)<P>(args)(Id);
 
 export type numberStr = number | `${number}`;

--- a/src/server/API/index.ts
+++ b/src/server/API/index.ts
@@ -28,3 +28,20 @@ export const {
   SERVER_ERROR,
   APPLICATION_ERROR,
 } = RPC_ERRORS_FNS;
+
+export {
+  createMCPRequest,
+  createMCPNotification,
+  createMCPResponse,
+  createMCPErrorResponse,
+} from '../../types/specs/mcp-bridge/factories';
+
+export {
+  MCPRequest,
+  MCPNotification,
+  MCPResponse,
+  isMCPMessage,
+  isMCPRequest,
+  isMCPNotification,
+  isMCPResponse,
+} from '../../types/specs/mcp-bridge/index';

--- a/src/server/job/asyncOnMessageWrap.ts
+++ b/src/server/job/asyncOnMessageWrap.ts
@@ -6,18 +6,19 @@ import type { IdsObject } from '../../types';
 import type { RpcRequest, RpcResponse } from '../../types/specs';
 import { swapRpcId } from '../API';
 import { errorHandler } from './errorHandler';
+import { isMCPMessage, MCPRequest, MCPResponse } from '../../types/specs/mcp-bridge';
 
 export function asyncOnMessageWrap(fn: Fn) {
-  return async (msg: RpcRequest<[IdsObject, ...string[]]>) =>
+  return async (msg: RpcRequest<[IdsObject, ...string[]]> | MCPRequest<[IdsObject, ...string[]]>) =>
     messageWrap(fn, msg);
 }
 export type Fn = (
-  msg: RpcRequest<[IdsObject, ...string[]]>
-) => Promise<RpcResponse<unknown>>;
+  msg: RpcRequest<[IdsObject, ...string[]]> | MCPRequest<[IdsObject, ...string[]]>
+) => Promise<RpcResponse<unknown> | MCPResponse<unknown>>;
 
 export async function messageWrap(
   fn: Fn,
-  msg: RpcRequest<[IdsObject, ...string[]]>
+  msg: RpcRequest<[IdsObject, ...string[]]> | MCPRequest<[IdsObject, ...string[]]>
 ) {
   try {
     if (!parentPort) {
@@ -25,7 +26,7 @@ export async function messageWrap(
     }
     const [{ external_message_identifier }] = getParams(msg);
     const currentId = swapRpcId(external_message_identifier, msg);
-    const result: RpcResponse<unknown> = await fn(msg);
+    const result: RpcResponse<unknown> | MCPResponse<unknown> = await fn(msg);
     swapRpcId(currentId, result);
     parentPort.postMessage(result);
   } catch (error) {

--- a/src/server/worker.ts
+++ b/src/server/worker.ts
@@ -10,6 +10,7 @@ import type { IdsObject } from '../types';
 import type { RpcRequest, RpcResponse } from '../types/specs';
 import { INTERNAL_ERROR } from './API';
 import { asyncOnMessageWrap, errorHandler } from './job/';
+import { MCPRequest, MCPResponse } from '../types/specs/mcp-bridge';
 
 const VERBOSE = true;
 const workerAsset = workerData.workerAsset;
@@ -29,8 +30,8 @@ void (function MAIN(): number {
 
       asyncOnMessageWrap(
         async (
-          rpcRequest: RpcRequest<[IdsObject, ...string[]]>
-        ): Promise<RpcResponse<unknown>> => {
+          rpcRequest: RpcRequest<[IdsObject, ...string[]]> | MCPRequest<[IdsObject, ...string[]]>
+        ): Promise<RpcResponse<unknown> | MCPResponse<unknown>> => {
           const { method } = rpcRequest;
           try {
             // ++ Is awaited here to catch any errors.

--- a/src/types/specs/mcp-bridge/factories.ts
+++ b/src/types/specs/mcp-bridge/factories.ts
@@ -1,0 +1,46 @@
+import { MCPRequest, MCPResponse, MCPNotification } from './index';
+import * as MCP from '../mcp/schema';
+
+export const createMCPRequest = <P extends Record<string, unknown> | unknown[]>(
+  method: keyof typeof MCP.ClientRequest | keyof typeof MCP.ServerRequest,
+  params: P,
+  id: number | string
+): MCPRequest<P> => ({
+  jsonrpc: '2.0',
+  method,
+  params,
+  id,
+});
+
+export const createMCPNotification = <P extends Record<string, unknown> | unknown[]>(
+  method: keyof typeof MCP.ClientNotification | keyof typeof MCP.ServerNotification,
+  params?: P
+): MCPNotification => ({
+  jsonrpc: '2.0',
+  method,
+  params,
+});
+
+export const createMCPResponse = <R>(
+  id: number | string,
+  result: MCP.ClientResult | MCP.ServerResult
+): MCPResponse<R> => ({
+  jsonrpc: '2.0',
+  id,
+  result,
+});
+
+export const createMCPErrorResponse = <E>(
+  id: number | string | null,
+  code: number,
+  message: string,
+  data?: E
+): MCPResponse<never> => ({
+  jsonrpc: '2.0',
+  id,
+  error: {
+    code,
+    message,
+    data,
+  },
+});

--- a/src/types/specs/mcp-bridge/index.ts
+++ b/src/types/specs/mcp-bridge/index.ts
@@ -1,0 +1,52 @@
+import { RpcRequest, RpcNotification } from '../json-rpc-2.0/request-object';
+import { RpcResponse } from '../json-rpc-2.0/response-object';
+import * as MCP from '../mcp/schema';
+
+export type MCPRequest<P extends Record<string, unknown> | unknown[]> = RpcRequest<P> & {
+  method: keyof typeof MCP.ClientRequest | keyof typeof MCP.ServerRequest;
+};
+
+export type MCPNotification = RpcNotification<any> & {
+  method: keyof typeof MCP.ClientNotification | keyof typeof MCP.ServerNotification;
+};
+
+export type MCPResponse<R> = RpcResponse<R> & {
+  result?: MCP.ClientResult | MCP.ServerResult;
+};
+
+// Type guard to check if a message is an MCP message
+export const isMCPMessage = (message: any): message is MCP.JSONRPCMessage => {
+  return (
+    message.jsonrpc === '2.0' &&
+    (isMCPRequest(message) || isMCPNotification(message) || isMCPResponse(message))
+  );
+};
+
+// Type guards for specific message types
+export const isMCPRequest = (message: any): message is MCPRequest<any> => {
+  return (
+    'method' in message &&
+    'id' in message &&
+    (Object.keys(MCP.ClientRequest).includes(message.method) ||
+      Object.keys(MCP.ServerRequest).includes(message.method))
+  );
+};
+
+export const isMCPNotification = (message: any): message is MCPNotification => {
+  return (
+    'method' in message &&
+    !('id' in message) &&
+    (Object.keys(MCP.ClientNotification).includes(message.method) ||
+      Object.keys(MCP.ServerNotification).includes(message.method))
+  );
+};
+
+export const isMCPResponse = (message: any): message is MCPResponse<any> => {
+  return (
+    ('result' in message || 'error' in message) &&
+    'id' in message &&
+    (!message.result ||
+      Object.keys(MCP.ClientResult).includes(typeof message.result) ||
+      Object.keys(MCP.ServerResult).includes(typeof message.result))
+  );
+};


### PR DESCRIPTION
Add support for MCP types and integrate them with existing JSON-RPC 2.0 implementation.

* **New Files**:
  - Add `src/types/specs/mcp-bridge/index.ts` to define `MCPRequest`, `MCPNotification`, and `MCPResponse` types, and implement type guards and `isMCPMessage` function.
  - Add `src/types/specs/mcp-bridge/factories.ts` to implement `createMCPRequest`, `createMCPNotification`, `createMCPResponse`, and `createMCPErrorResponse` functions.

* **Modified Files**:
  - `src/commands/tools/createComand.ts`: Modify `createRPCRequest` and `createRPCResponse` to support MCP types.
  - `src/server/API/baseRpcRequest.ts`: Modify `rpcRequestMethodHandler` to support MCP types.
  - `src/server/API/index.ts`: Export new functions and types from `src/types/specs/mcp-bridge/index.ts` and `src/types/specs/mcp-bridge/factories.ts`.
  - `src/server/API/RPC-serialise.ts`: Modify `baseRpcResponseRight` to support MCP types.
  - `src/server/job/asyncOnMessageWrap.ts`: Modify `asyncOnMessageWrap` to support MCP types.
  - `src/server/worker.ts`: Modify worker to support MCP types.
  - `src/core/RpcWorkerPool.ts`: Modify `RpcWorkerPool` to support MCP types.
  - `src/core/RpcWorkerPool-slim.ts`: Modify `RpcWorkerPool` to support MCP types.

